### PR TITLE
Fixed jsdoc module paths to work with jsdoc3 master

### DIFF
--- a/src/net/jannon/ant/tasks/JsDoc3.java
+++ b/src/net/jannon/ant/tasks/JsDoc3.java
@@ -199,7 +199,9 @@ public class JsDoc3 extends Task {
 		arguments.add("-modules");
 		arguments.add(jsDocHome + "/node_modules");
 		arguments.add("-modules");
-		arguments.add(jsDocHome + "/rhino_modules");
+		arguments.add(jsDocHome + "/rhino");
+		arguments.add("-modules");
+		arguments.add(jsDocHome + "/lib");
 		arguments.add("-modules");
 		arguments.add(jsDocHome);
 		


### PR DESCRIPTION
The jsdoc paths didn't provided by the task were not correct, preventing the ant task from working with the current jsdoc master. The correct paths were taken from the wrapping script provided along with jsdoc3.
